### PR TITLE
update d3-color to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "d3-bundler": "~0.2.6",
-    "d3-color": "~0.2.0",
+    "d3-color": "~0.2.5",
     "faucet": "0.0",
     "tape": "4",
     "uglify-js": "2"


### PR DESCRIPTION
`Map` is still showing up in the built versions of this lib because it relies on an older version of d3-color.  Can I pester you for an update?

Thanks!
 