### PR TITLE
interpolated array should be the same length as end array

### DIFF
--- a/src/array.js
+++ b/src/array.js
@@ -15,6 +15,6 @@ export default function(a, b) {
 
   return function(t) {
     for (i = 0; i < n0; ++i) c[i] = x[i](t);
-    return c;
+    return c.slice(0, nb);
   };
 }

--- a/src/array.js
+++ b/src/array.js
@@ -10,11 +10,10 @@ export default function(a, b) {
       i;
 
   for (i = 0; i < n0; ++i) x.push(value(a[i], b[i]));
-  for (; i < na; ++i) c[i] = a[i];
   for (; i < nb; ++i) c[i] = b[i];
 
   return function(t) {
     for (i = 0; i < n0; ++i) c[i] = x[i](t);
-    return c.slice(0, nb);
+    return c;
   };
 }

--- a/test/array-test.js
+++ b/test/array-test.js
@@ -12,15 +12,19 @@ tape("interpolateArray(a, b) interpolates nested objects and arrays", function(t
   test.end();
 });
 
-tape("interpolateArray(a, b) merges non-shared elements", function(test) {
+tape("interpolateArray(a, b) merges non-shared elements of array b", function(test) {
   test.deepEqual(interpolate.interpolateArray([2, 12], [4, 24, 12])(0.5), [3, 18, 12]);
-  test.deepEqual(interpolate.interpolateArray([2, 12, 12], [4, 24])(0.5), [3, 18, 12]);
+  test.end();
+});
+
+tape("interpolateArray(a, b) doesn't merge non-shared elements of array a", function(test) {
+  test.deepEqual(interpolate.interpolateArray([2, 12, 12], [4, 24])(0.5), [3, 18]);
   test.end();
 });
 
 tape("interpolateArray(a, b) treats undefined as an empty array", function(test) {
   test.deepEqual(interpolate.interpolateArray(undefined, [2, 12])(0.5), [2, 12]);
-  test.deepEqual(interpolate.interpolateArray([2, 12], undefined)(0.5), [2, 12]);
+  test.deepEqual(interpolate.interpolateArray([2, 12], undefined)(0.5), []);
   test.deepEqual(interpolate.interpolateArray(undefined, undefined)(0.5), []);
   test.end();
 });


### PR DESCRIPTION
I'm using `d3-interpolate` for animating between datasets. When the length of the dataset changes, I end up with old data sticking around in my interpolated dataset. I think having extra data from the start array remain in the interpolated array is incorrect behavior. Please consider this change.

Thanks!