### PR TITLE
Interpolate objects without prototype

### DIFF
--- a/src/value.js
+++ b/src/value.js
@@ -15,6 +15,6 @@ export default function(a, b) {
       : b instanceof color ? rgb
       : b instanceof Date ? date
       : Array.isArray(b) ? array
-      : !b.valueOf || isNaN(b)) ? object
+      : !b.valueOf || isNaN(b) ? object
       : number)(a, b);
 }

--- a/src/value.js
+++ b/src/value.js
@@ -15,6 +15,6 @@ export default function(a, b) {
       : b instanceof color ? rgb
       : b instanceof Date ? date
       : Array.isArray(b) ? array
-      : isNaN(b) ? object
+      : (!b.valueOf || isNaN(b)) ? object
       : number)(a, b);
 }

--- a/src/value.js
+++ b/src/value.js
@@ -15,6 +15,6 @@ export default function(a, b) {
       : b instanceof color ? rgb
       : b instanceof Date ? date
       : Array.isArray(b) ? array
-      : !b.valueOf || isNaN(b) ? object
+      : typeof b.valueOf !== "function" && typeof b.toString !== "function" || isNaN(b) ? object
       : number)(a, b);
 }

--- a/src/value.js
+++ b/src/value.js
@@ -15,6 +15,6 @@ export default function(a, b) {
       : b instanceof color ? rgb
       : b instanceof Date ? date
       : Array.isArray(b) ? array
-      : (!b.valueOf || isNaN(b)) ? object
+      : ((!b.valueOf && !b.toString) || isNaN(b)) ? object
       : number)(a, b);
 }

--- a/src/value.js
+++ b/src/value.js
@@ -15,6 +15,6 @@ export default function(a, b) {
       : b instanceof color ? rgb
       : b instanceof Date ? date
       : Array.isArray(b) ? array
-      : ((!b.valueOf && !b.toString) || isNaN(b)) ? object
+      : !b.valueOf || isNaN(b)) ? object
       : number)(a, b);
 }

--- a/test/object-test.js
+++ b/test/object-test.js
@@ -48,3 +48,14 @@ tape("interpolateObject(a, b) treats undefined as an empty object", function(tes
   test.deepEqual(interpolate.interpolateObject(null, NaN)(0.5), {});
   test.end();
 });
+
+tape("interpolateObject(a, b) interpolates objects without prototype", function(test) {
+  function noProto(properties) {
+    return Object.assign(
+      Object.create(null),
+      properties
+    );
+  }
+  test.deepEqual(interpolate.interpolateObject(noProto({foo: 0}), noProto({foo: 2}))(0.5), {foo: 1});
+  test.end();
+});

--- a/test/object-test.js
+++ b/test/object-test.js
@@ -50,12 +50,10 @@ tape("interpolateObject(a, b) treats undefined as an empty object", function(tes
 });
 
 tape("interpolateObject(a, b) interpolates objects without prototype", function(test) {
-  function noProto(properties) {
-    return Object.assign(
-      Object.create(null),
-      properties
-    );
-  }
-  test.deepEqual(interpolate.interpolateObject(noProto({foo: 0}), noProto({foo: 2}))(0.5), {foo: 1});
+  test.deepEqual(interpolate.interpolateObject(noproto({foo: 0}), noproto({foo: 2}))(0.5), {foo: 1});
   test.end();
 });
+
+function noproto(properties) {
+  return Object.assign(Object.create(null), properties);
+}

--- a/test/value-test.js
+++ b/test/value-test.js
@@ -73,3 +73,12 @@ tape("interpolate(a, b) returns the constant b if b is null, undefined or a bool
   test.strictEqual(interpolate.interpolate(0, false)(0.5), false);
   test.end();
 });
+
+tape("interpolate(a, b) interpolates objects without prototype", function(test) {
+  test.deepEqual(interpolate.interpolate(noproto({foo: 0}), noproto({foo: 2}))(0.5), {foo: 1});
+  test.end();
+});
+
+function noproto(properties) {
+  return Object.assign(Object.create(null), properties);
+}

--- a/test/value-test.js
+++ b/test/value-test.js
@@ -79,6 +79,53 @@ tape("interpolate(a, b) interpolates objects without prototype", function(test) 
   test.end();
 });
 
-function noproto(properties) {
-  return Object.assign(Object.create(null), properties);
+tape("interpolate(a, b) interpolates objects with numeric valueOf as numbers", function(test) {
+  var proto = {valueOf: foo};
+  test.deepEqual(interpolate.interpolate(noproto({foo: 0}, proto), noproto({foo: 2}, proto))(0.5), 1);
+  test.end();
+});
+
+tape("interpolate(a, b) interpolates objects with string valueOf as numbers if valueOf result is coercible to number", function(test) {
+  var proto = {valueOf: fooString};
+  test.deepEqual(interpolate.interpolate(noproto({foo: 0}, proto), noproto({foo: 2}, proto))(0.5), 1);
+  test.end();
+});
+
+tape("interpolate(a, b) interpolates objects with string valueOf as objects if valueOf result is not coercible to number", function(test) {
+  var proto = {valueOf: fooString};
+  
+  // valueOf appears here as object because:
+  // - we use for-in loop and it will ignore only fields coming from built-in prototypes;
+  // - we replace functions with objects.
+  test.deepEqual(interpolate.interpolate(noproto({foo: "bar"}, proto), noproto({foo: "baz"}, proto))(0.5), {foo: "baz", valueOf: {}});
+  test.end();
+});
+
+
+tape("interpolate(a, b) interpolates objects with toString as numbers if toString result is coercible to number", function(test) {
+  var proto = {toString: fooString};
+  test.deepEqual(interpolate.interpolate(noproto({foo: 0}, proto), noproto({foo: 2}, proto))(0.5), 1);
+  test.end();
+});
+
+tape("interpolate(a, b) interpolates objects with toString as objects if toString result is not coercible to number", function(test) {
+  var proto = {toString: fooString};
+  
+  // toString appears here as object because:
+  // - we use for-in loop and it will ignore only fields coming from built-in prototypes;
+  // - we replace functions with objects.
+  test.deepEqual(interpolate.interpolate(noproto({foo: "bar"}, proto), noproto({foo: "baz"}, proto))(0.5), {foo: "baz", toString: {}});
+  test.end();
+});
+
+function noproto(properties, proto = null) {
+  return Object.assign(Object.create(proto), properties);
+}
+
+function foo() {
+  return this.foo;
+}
+
+function fooString() {
+  return String(this.foo);
 }


### PR DESCRIPTION
Trying to interpolate objects without prototype (and thus without valueOf and toString) results in error due to isNaN call. It fails when both methods are absent.

I've modified corresponding file to check whether at least one of valueOf or toString are present.

isNaN check has no meaning when both methods are absent because we can say for sure that variable is not a number.