### PR TITLE
interpolateString: clarify docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Returns an interpolator between the two strings *a* and *b*. The string interpol
 
 For each number embedded in *b*, the interpolator will attempt to find a corresponding number in *a*. If a corresponding number is found, a numeric interpolator is created using [interpolateNumber](#interpolateNumber). The remaining parts of the string *b* are used as a template: the static parts of the string *b* remain constant for the interpolation, with the interpolated numeric values embedded in the template.
 
-For example, if *a* is `"300 12px sans-serif"`, and *b* is `"500 36px Comic-Sans"`, two embedded numbers are found. The remaining static parts of the string are a space between the two numbers (`" "`), and the suffix (`"px Comic-Sans"`). The result of the interpolator at *t* = 0.5 is `"400 24px Comic-Sans"`.
+For example, if *a* is `"300 12px sans-serif"`, and *b* is `"500 36px Comic-Sans"`, two embedded numbers are found. The remaining static parts (of string *b*) are a space between the two numbers (`" "`), and the suffix (`"px Comic-Sans"`). The result of the interpolator at *t* = 0.5 is `"400 24px Comic-Sans"`.
 
 <a name="interpolateDate" href="#interpolateDate">#</a> d3.<b>interpolateDate</b>(<i>a</i>, <i>b</i>) [<>](https://github.com/d3/d3-interpolate/blob/master/src/date.js "Source")
 


### PR DESCRIPTION
The example paragraph for `interpolateString` was worded ambiguously ("The remaining static parts of the string", without specifying which string is being talked about); so unless one had already grasped how the function is supposed to work from the abstract description in the paragraphs above, the interpolation result would be surprising and unclear. The documentation thus fails "bottom-up" learners (i.e. those who learn best by example).

This change is a proposed clarification of the example paragraph by explicitly mentioning the *b* string. Suggestions for alternative wording / punctuation are welcome.