### PR TITLE
Fix number interpolator ending value for very large a

### DIFF
--- a/src/number.js
+++ b/src/number.js
@@ -1,5 +1,6 @@
 export default function(a, b) {
-  return a = +a, b -= a, function(t) {
-    return a + b * t;
+  const d = b - a;
+  return a = +a, function(t) {
+    return t === 1 ? +b : a + d * t;
   };
 }

--- a/test/number-test.js
+++ b/test/number-test.js
@@ -18,3 +18,10 @@ tape("interpolateNumber(a, b) interpolates between two numbers a and b", functio
   test.inDelta(i(1.0), 42.0);
   test.end();
 });
+
+tape("interpolateNumber(a, b) always returns b for t=1 (also for very large a)", function(test) {
+  var i = interpolate.interpolateNumber(2e+42, 335);
+  test.equal(i(0.0), 2e+42);
+  test.equal(i(1.0), 335);
+  test.end();
+});


### PR DESCRIPTION
### Current situation: 
When a number interpolator is applied to a very large floating point number starting value, the ending is 0.

```
var i = interpolate.interpolateNumber(2e+42, 335);
i(1.0) === 0 // !
```

This is due to floating point number arithmetic errors:

```
var a = 2e+42;
var b = 335
var delta = b - a;
delta === -2e+42 // !
```

### Fix 
There is IMO no perfect fix for the calculation for 0<t<1, 
but for t===1, the ending value should be returned (without any calculation).

