### PR TITLE
Interpolate typed array folded

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,9 @@ Returns an interpolator between the two arbitrary values *a* and *b*. The interp
 3. If *b* is a [color](https://github.com/d3/d3-color/blob/master/README.md#color) or a string coercible to a color, use [interpolateRgb](#interpolateRgb).
 4. If *b* is a [date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date), use [interpolateDate](#interpolateDate).
 5. If *b* is a string, use [interpolateString](#interpolateString).
-6. If *b* is an [array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray), use [interpolateArray](#interpolateArray).
-7. If *b* is a [typed array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray), use [interpolateTypedArray](#interpolateTypedArray).
-8. If *b* is coercible to a number, use [interpolateNumber](#interpolateNumber).
-9. Use [interpolateObject](#interpolateObject).
+6. If *b* is an [array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray) or a [typed array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray), use [interpolateArray](#interpolateArray).
+7. If *b* is coercible to a number, use [interpolateNumber](#interpolateNumber).
+8. Use [interpolateObject](#interpolateObject).
 
 Based on the chosen interpolator, *a* is coerced to the suitable corresponding type.
 
@@ -97,7 +96,11 @@ Returns an interpolator between the two arrays *a* and *b*. Internally, an array
 
 For example, if *a* is the array `[0, 1]` and *b* is the array `[1, 10, 100]`, then the result of the interpolator for *t* = 0.5 is the array `[0.5, 5.5, 100]`.
 
-Note: **no defensive copy** of the template array is created; modifications of the returned array may adversely affect subsequent evaluation of the interpolator. No copy is made for performance reasons; interpolators are often part of the inner loop of [animated transitions](https://github.com/d3/d3-transition).
+When *b* is a typed array, instead of creating a range of interpolators, interpolateArray creates a template typed array with the same length and type as *b*, and returns it, with appropriately interpolated values.
+
+For example, if *a* is `Float32Array.from([0, 1])` and *b* is `Float64Array.from([1, 10, 100])`, then the result of the interpolator for *t* = 0.5 is the Float64Array `[0.5, 5.5, 100]`.
+
+Note: **no defensive copy** of the template array is created; modifications of the returned array may adversely affect subsequent evaluation of the interpolator. No copy is made for performance reasons; interpolators are often part of the inner loop of [animated transitions](https://github.com/d3/d3-transition). In the case of typed arrays *a* and *b*, no defensive copy of these arguments are made either.
 
 <a name="interpolateObject" href="#interpolateObject">#</a> d3.<b>interpolateObject</b>(<i>a</i>, <i>b</i>) · [Source](https://github.com/d3/d3-interpolate/blob/master/src/object.js), [Examples](https://observablehq.com/@d3/d3-interpolateobject)
 
@@ -108,14 +111,6 @@ For example, if *a* is the object `{x: 0, y: 1}` and *b* is the object `{x: 1, y
 Object interpolation is particularly useful for *dataspace interpolation*, where data is interpolated rather than attribute values. For example, you can interpolate an object which describes an arc in a pie chart, and then use [d3.arc](https://github.com/d3/d3-shape/blob/master/README.md#arc) to compute the new SVG path data.
 
 Note: **no defensive copy** of the template object is created; modifications of the returned object may adversely affect subsequent evaluation of the interpolator. No copy is made for performance reasons; interpolators are often part of the inner loop of [animated transitions](https://github.com/d3/d3-transition).
-
-<a name="interpolateTypedArray" href="#interpolateTypedArray">#</a> d3.<b>interpolateTypedArray</b>(<i>a</i>, <i>b</i>) · [Source](https://github.com/d3/d3-interpolate/blob/master/src/typedArray.js)
-
-Returns an interpolator between the typed arrays *a* and *b*. Internally, a template array is created with the same length and type as *b*. For each element in *b*, if there exists a corresponding element in *a*, the numbers are interpolated linearly and the result saved in the template. If there is no such element, the static value from *b* is used. The updated array template is then returned.
-
-For example, if *a* is `Float32Array.from([0, 1])` and *b* is `Float64Array.from([1, 10, 100])`, then the result of the interpolator for *t* = 0.5 is the Float64Array `[0.5, 5.5, 100]`.
-
-Note: for performance reasons, **no defensive copy** of the arguments and template arrays is created; modifications of any of them may affect subsequent evaluation of the interpolator.
 
 <a name="interpolateTransformCss" href="#interpolateTransformCss">#</a> d3.<b>interpolateTransformCss</b>(<i>a</i>, <i>b</i>) · [Source](https://github.com/d3/d3-interpolate/blob/master/src/transform/index.js#L62), [Examples](https://observablehq.com/@d3/d3-interpolatetransformcss)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Note that the generic value interpolator detects not only nested objects and arr
 
 ## Installing
 
-If you use NPM, `npm install d3-interpolate`. Otherwise, download the [latest release](https://github.com/d3/d3-interpolate/releases/latest). You can also load directly from [d3js.org](https://d3js.org), either as a [standalone library](https://d3js.org/d3-interpolate.v1.min.js) or as part of [D3 4.0](https://github.com/d3/d3). AMD, CommonJS, and vanilla environments are supported. In vanilla, a `d3` global is exported:
+If you use NPM, `npm install d3-interpolate`. Otherwise, download the [latest release](https://github.com/d3/d3-interpolate/releases/latest). You can also load directly from [d3js.org](https://d3js.org), either as a [standalone library](https://d3js.org/d3-interpolate.v1.min.js) or as part of [D3](https://github.com/d3/d3). AMD, CommonJS, and vanilla environments are supported. In vanilla, a `d3` global is exported:
 
 ```html
 <script src="https://d3js.org/d3-color.v1.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-interpolate",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Interpolate numbers, colors, strings, arrays, objects, whatever!",
   "keywords": [
     "d3",
@@ -36,6 +36,7 @@
   "dependencies": {
     "d3-color": "1"
   },
+  "sideEffects": false,
   "devDependencies": {
     "eslint": "6",
     "rollup": "1",

--- a/src/array.js
+++ b/src/array.js
@@ -1,6 +1,8 @@
 import value from "./value.js";
+import {default as typedArray, isTypedArray} from "./typedArray.js";
 
 export default function(a, b) {
+  if (isTypedArray(b)) return typedArray(a, b);
   var nb = b ? b.length : 0,
       na = a ? Math.min(nb, a.length) : 0,
       x = new Array(na),

--- a/src/typedArray.js
+++ b/src/typedArray.js
@@ -8,3 +8,7 @@ export default function(a, b) {
     return c;
   };
 }
+
+export function isTypedArray(x) {
+  return ArrayBuffer.isView(x) && !(x instanceof DataView);
+}

--- a/src/value.js
+++ b/src/value.js
@@ -5,8 +5,8 @@ import date from "./date.js";
 import number from "./number.js";
 import object from "./object.js";
 import string from "./string.js";
-import typedArray from "./typedArray.js";
 import constant from "./constant.js";
+import {default as typedArray, isTypedArray} from "./typedArray.js";
 
 export default function(a, b) {
   var t = typeof b, c;
@@ -19,8 +19,4 @@ export default function(a, b) {
       : isTypedArray(b) ? typedArray
       : typeof b.valueOf !== "function" && typeof b.toString !== "function" || isNaN(b) ? object
       : number)(a, b);
-}
-
-function isTypedArray(x) {
-  return ArrayBuffer.isView(x) && !(x instanceof DataView);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -250,16 +250,16 @@ eslint-scope@^5.0.0:
     estraverse "^4.1.1"
 
 eslint-utils@^1.3.1:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.0.tgz#e2c3c8dba768425f897cf0f9e51fe2e241485d4c"
-  integrity sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
+  integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
   dependencies:
-    eslint-visitor-keys "^1.0.0"
+    eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
-  integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
+eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
+  integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
 eslint@6:
   version "6.1.0"


### PR DESCRIPTION
This variant of https://github.com/d3/d3-interpolate/pull/65 folds interpolateTypedArray into interpolateArray.

The only part I find weird is in README, where we explain that no defensive copy of the template array is made, nor, in the case of typed array, do we have defensive copies of *a* and *b*. Not sure if this is intelligible at all.