### PR TITLE
interpolateNumberArray

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ Returns an interpolator between the two arbitrary values *a* and *b*. The interp
 3. If *b* is a [color](https://github.com/d3/d3-color/blob/master/README.md#color) or a string coercible to a color, use [interpolateRgb](#interpolateRgb).
 4. If *b* is a [date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date), use [interpolateDate](#interpolateDate).
 5. If *b* is a string, use [interpolateString](#interpolateString).
-6. If *b* is an [array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray), use [interpolateArray](#interpolateArray).
-7. If *b* is coercible to a number, use [interpolateNumber](#interpolateNumber).
-8. Use [interpolateObject](#interpolateObject).
+6. If *b* is a number array (a [typed array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) or an array containing only numbers, use [interpolateNumberArray](#interpolateNumberArray).
+7. If *b* is a generic [array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray), use [interpolateArray](#interpolateArray).
+8. If *b* is coercible to a number, use [interpolateNumber](#interpolateNumber).
+9. Use [interpolateObject](#interpolateObject).
 
 Based on the chosen interpolator, *a* is coerced to the suitable corresponding type.
 
@@ -92,11 +93,19 @@ Note: **no defensive copy** of the returned date is created; the same Date insta
 
 <a name="interpolateArray" href="#interpolateArray">#</a> d3.<b>interpolateArray</b>(<i>a</i>, <i>b</i>) · [Source](https://github.com/d3/d3-interpolate/blob/master/src/array.js), [Examples](https://observablehq.com/@d3/d3-interpolateobject)
 
-Returns an interpolator between the two arrays *a* and *b*. Internally, an array template is created that is the same length in *b*. For each element in *b*, if there exists a corresponding element in *a*, a generic interpolator is created for the two elements using [interpolate](#interpolate). If there is no such element, the static value from *b* is used in the template. Then, for the given parameter *t*, the template’s embedded interpolators are evaluated. The updated array template is then returned.
+Returns an interpolator between the two arrays *a* and *b*. Internally, an array template is created that is the same length as *b*. For each element in *b*, if there exists a corresponding element in *a*, a generic interpolator is created for the two elements using [interpolate](#interpolate). If there is no such element, the static value from *b* is used in the template. Then, for the given parameter *t*, the template’s embedded interpolators are evaluated. The updated array template is then returned.
 
 For example, if *a* is the array `[0, 1]` and *b* is the array `[1, 10, 100]`, then the result of the interpolator for *t* = 0.5 is the array `[0.5, 5.5, 100]`.
 
 Note: **no defensive copy** of the template array is created; modifications of the returned array may adversely affect subsequent evaluation of the interpolator. No copy is made for performance reasons; interpolators are often part of the inner loop of [animated transitions](https://github.com/d3/d3-transition).
+
+If the array is a typed array (Float64Array, etc) or contains only numbers, the interpolateNumberArray method is called instead.
+
+<a name="interpolateNumberArray" href="#interpolateNumberArray">#</a> d3.<b>interpolateNumberArray</b>(<i>a</i>, <i>b</i>) · [Source](https://github.com/d3/d3-interpolate/blob/master/src/numberArray.js) <!-- , [Examples](https://observablehq.com/@d3/d3-interpolateobject) -->
+
+Returns an interpolator between the two number arrays *a* and *b*. Internally, an array template is created that is the same type and length as *b*. For each element in *b*, if there exists a corresponding element in *a*, the values are directly interpolated in the array template. If there is no such element, the static value from *b* is copied. The updated array template is then returned.
+
+Note: For performance reasons, **no defensive copy** is made of the template array and the arguments *a* and *b*; modifications of these arrays may affect subsequent evaluation of the interpolator.
 
 <a name="interpolateObject" href="#interpolateObject">#</a> d3.<b>interpolateObject</b>(<i>a</i>, <i>b</i>) · [Source](https://github.com/d3/d3-interpolate/blob/master/src/object.js), [Examples](https://observablehq.com/@d3/d3-interpolateobject)
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Returns an interpolator between the two arbitrary values *a* and *b*. The interp
 3. If *b* is a [color](https://github.com/d3/d3-color/blob/master/README.md#color) or a string coercible to a color, use [interpolateRgb](#interpolateRgb).
 4. If *b* is a [date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date), use [interpolateDate](#interpolateDate).
 5. If *b* is a string, use [interpolateString](#interpolateString).
-6. If *b* is a number array (a [typed array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) or an array containing only numbers, use [interpolateNumberArray](#interpolateNumberArray).
+6. If *b* is a [typed array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) of numbers, use [interpolateNumberArray](#interpolateNumberArray).
 7. If *b* is a generic [array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray), use [interpolateArray](#interpolateArray).
 8. If *b* is coercible to a number, use [interpolateNumber](#interpolateNumber).
 9. Use [interpolateObject](#interpolateObject).
@@ -99,7 +99,7 @@ For example, if *a* is the array `[0, 1]` and *b* is the array `[1, 10, 100]`, t
 
 Note: **no defensive copy** of the template array is created; modifications of the returned array may adversely affect subsequent evaluation of the interpolator. No copy is made for performance reasons; interpolators are often part of the inner loop of [animated transitions](https://github.com/d3/d3-transition).
 
-If the array is a typed array (Float64Array, etc) or contains only numbers, the interpolateNumberArray method is called instead.
+If the array is a typed array (Float64Array, etc), the interpolateNumberArray method is called instead.
 
 <a name="interpolateNumberArray" href="#interpolateNumberArray">#</a> d3.<b>interpolateNumberArray</b>(<i>a</i>, <i>b</i>) · [Source](https://github.com/d3/d3-interpolate/blob/master/src/numberArray.js) <!-- , [Examples](https://observablehq.com/@d3/d3-interpolateobject) -->
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Note: **no defensive copy** of the template array is created; modifications of t
 
 If the array is a typed array (Float64Array, etc), the interpolateNumberArray method is called instead.
 
-<a name="interpolateNumberArray" href="#interpolateNumberArray">#</a> d3.<b>interpolateNumberArray</b>(<i>a</i>, <i>b</i>) · [Source](https://github.com/d3/d3-interpolate/blob/master/src/numberArray.js) <!-- , [Examples](https://observablehq.com/@d3/d3-interpolateobject) -->
+<a name="interpolateNumberArray" href="#interpolateNumberArray">#</a> d3.<b>interpolateNumberArray</b>(<i>a</i>, <i>b</i>) · [Source](https://github.com/d3/d3-interpolate/blob/master/src/numberArray.js), [Examples](https://observablehq.com/@d3/d3-interpolatenumberarray)
 
 Returns an interpolator between the two number arrays *a* and *b*. Internally, an array template is created that is the same type and length as *b*. For each element in *b*, if there exists a corresponding element in *a*, the values are directly interpolated in the array template. If there is no such element, the static value from *b* is copied. The updated array template is then returned.
 

--- a/src/array.js
+++ b/src/array.js
@@ -2,7 +2,10 @@ import value from "./value.js";
 import numberArray, {isNumberArray} from "./numberArray.js";
 
 export default function(a, b) {
-  if (isNumberArray(b)) return numberArray(a, b);
+  return (isNumberArray(b) ? numberArray : genericArray)(a, b);
+}
+
+export function genericArray(a, b) {
   var nb = b ? b.length : 0,
       na = a ? Math.min(nb, a.length) : 0,
       x = new Array(na),

--- a/src/array.js
+++ b/src/array.js
@@ -1,5 +1,5 @@
 import value from "./value.js";
-import {default as numberArray, isNumberArray} from "./numberArray.js";
+import numberArray, {isNumberArray} from "./numberArray.js";
 
 export default function(a, b) {
   if (isNumberArray(b)) return numberArray(a, b);

--- a/src/array.js
+++ b/src/array.js
@@ -1,6 +1,8 @@
 import value from "./value.js";
+import {default as numberArray, isNumberArray} from "./numberArray.js";
 
 export default function(a, b) {
+  if (isNumberArray(b)) return numberArray(a, b);
   var nb = b ? b.length : 0,
       na = a ? Math.min(nb, a.length) : 0,
       x = new Array(na),

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ export {default as interpolateDate} from "./date.js";
 export {default as interpolateDiscrete} from "./discrete.js";
 export {default as interpolateHue} from "./hue.js";
 export {default as interpolateNumber} from "./number.js";
+export {default as interpolateNumberArray} from "./numberArray.js";
 export {default as interpolateObject} from "./object.js";
 export {default as interpolateRound} from "./round.js";
 export {default as interpolateString} from "./string.js";

--- a/src/numberArray.js
+++ b/src/numberArray.js
@@ -1,8 +1,8 @@
 export default function(a, b) {
   if (!b) b = [];
   var na = a ? Math.min(b.length, a.length) : 0,
-    c = b.slice();
-  let i;
+    c = b.slice(),
+    i;
   return function(t) {
     for (i = 0; i < na; ++i) c[i] = a[i] + (b[i] - a[i]) * t;
     return c;

--- a/src/numberArray.js
+++ b/src/numberArray.js
@@ -1,0 +1,15 @@
+export default function(a, b) {
+  if (!b) b = [];
+  var na = a ? Math.min(b.length, a.length) : 0,
+    c = b.slice();
+  let i;
+  return function(t) {
+    for (i = 0; i < na; ++i) c[i] = a[i] + (b[i] - a[i]) * t;
+    return c;
+  };
+}
+
+export function isNumberArray(x) {
+  if (ArrayBuffer.isView(x)) return !(x instanceof DataView);
+  return Array.isArray(x) && x.every(i => typeof i == "number");
+}

--- a/src/numberArray.js
+++ b/src/numberArray.js
@@ -1,10 +1,10 @@
 export default function(a, b) {
   if (!b) b = [];
-  var na = a ? Math.min(b.length, a.length) : 0,
-    c = b.slice(),
-    i;
+  var n = a ? Math.min(b.length, a.length) : 0,
+      c = b.slice(),
+      i;
   return function(t) {
-    for (i = 0; i < na; ++i) c[i] = a[i] * (1 - t) + b[i] * t;
+    for (i = 0; i < n; ++i) c[i] = a[i] * (1 - t) + b[i] * t;
     return c;
   };
 }

--- a/src/numberArray.js
+++ b/src/numberArray.js
@@ -10,6 +10,5 @@ export default function(a, b) {
 }
 
 export function isNumberArray(x) {
-  if (ArrayBuffer.isView(x)) return !(x instanceof DataView);
-  return Array.isArray(x) && x.every(i => typeof i == "number");
+  return ArrayBuffer.isView(x) && !(x instanceof DataView);
 }

--- a/src/numberArray.js
+++ b/src/numberArray.js
@@ -4,7 +4,7 @@ export default function(a, b) {
     c = b.slice(),
     i;
   return function(t) {
-    for (i = 0; i < na; ++i) c[i] = a[i] + (b[i] - a[i]) * t;
+    for (i = 0; i < na; ++i) c[i] = a[i] * (1 - t) + b[i] * t;
     return c;
   };
 }

--- a/src/value.js
+++ b/src/value.js
@@ -6,6 +6,7 @@ import number from "./number.js";
 import object from "./object.js";
 import string from "./string.js";
 import constant from "./constant.js";
+import {default as numberArray, isNumberArray} from "./numberArray.js";
 
 export default function(a, b) {
   var t = typeof b, c;
@@ -14,6 +15,7 @@ export default function(a, b) {
       : t === "string" ? ((c = color(b)) ? (b = c, rgb) : string)
       : b instanceof color ? rgb
       : b instanceof Date ? date
+      : isNumberArray(b) ? numberArray
       : Array.isArray(b) ? array
       : typeof b.valueOf !== "function" && typeof b.toString !== "function" || isNaN(b) ? object
       : number)(a, b);

--- a/src/value.js
+++ b/src/value.js
@@ -1,6 +1,6 @@
 import {color} from "d3-color";
 import rgb from "./rgb.js";
-import array from "./array.js";
+import {genericArray} from "./array.js";
 import date from "./date.js";
 import number from "./number.js";
 import object from "./object.js";
@@ -16,7 +16,7 @@ export default function(a, b) {
       : b instanceof color ? rgb
       : b instanceof Date ? date
       : isNumberArray(b) ? numberArray
-      : Array.isArray(b) ? array
+      : Array.isArray(b) ? genericArray
       : typeof b.valueOf !== "function" && typeof b.toString !== "function" || isNaN(b) ? object
       : number)(a, b);
 }

--- a/src/value.js
+++ b/src/value.js
@@ -6,7 +6,7 @@ import number from "./number.js";
 import object from "./object.js";
 import string from "./string.js";
 import constant from "./constant.js";
-import {default as numberArray, isNumberArray} from "./numberArray.js";
+import numberArray, {isNumberArray} from "./numberArray.js";
 
 export default function(a, b) {
   var t = typeof b, c;

--- a/test/numberArray-test.js
+++ b/test/numberArray-test.js
@@ -1,0 +1,37 @@
+var tape = require("tape"),
+    interpolate = require("../");
+
+tape("interpolateNumberArray(a, b) interpolates defined elements in a and b", function(test) {
+  test.deepEqual(interpolate.interpolateNumberArray(Float64Array.from([2, 12]), Float64Array.from([4, 24]))(0.5), Float64Array.from([3, 18]));
+  test.end();
+});
+
+tape("interpolateNumberArray(a, b) ignores elements in a that are not in b", function(test) {
+  test.deepEqual(interpolate.interpolateNumberArray(Float64Array.from([2, 12, 12]), Float64Array.from([4, 24]))(0.5), Float64Array.from([3, 18]));
+  test.end();
+});
+
+tape("interpolateNumberArray(a, b) uses constant elements in b that are not in a", function(test) {
+  test.deepEqual(interpolate.interpolateNumberArray(Float64Array.from([2, 12]), Float64Array.from([4, 24, 12]))(0.5), Float64Array.from([3, 18, 12]));
+  test.end();
+});
+
+tape("interpolateNumberArray(a, b) treats undefined as an empty array", function(test) {
+  test.deepEqual(interpolate.interpolateNumberArray(undefined, [2, 12])(0.5), [2, 12]);
+  test.deepEqual(interpolate.interpolateNumberArray([2, 12], undefined)(0.5), []);
+  test.deepEqual(interpolate.interpolateNumberArray(undefined, undefined)(0.5), []);
+  test.end();
+});
+
+tape("interpolateNumberArray(a, b) uses b’s array type", function(test) {
+  test.ok(interpolate.interpolateNumberArray(Float64Array.from([2, 12]), Float64Array.from([4, 24, 12]))(0.5) instanceof Float64Array);
+  test.ok(interpolate.interpolateNumberArray(Float64Array.from([2, 12]), Float32Array.from([4, 24, 12]))(0.5) instanceof Float32Array);
+  test.ok(interpolate.interpolateNumberArray(Float64Array.from([2, 12]), Uint8Array.from([4, 24, 12]))(0.5) instanceof Uint8Array);
+  test.ok(interpolate.interpolateNumberArray(Float64Array.from([2, 12]), Uint16Array.from([4, 24, 12]))(0.5) instanceof Uint16Array);
+  test.end();
+});
+
+tape("interpolateNumberArray(a, b) works with unsigned data", function(test) {
+  test.deepEqual(interpolate.interpolateNumberArray(Uint8Array.from([1, 12]), Uint8Array.from([255, 0]))(0.5), Uint8Array.from([128, 6]));
+  test.end();
+});

--- a/test/numberArray-test.js
+++ b/test/numberArray-test.js
@@ -2,17 +2,17 @@ var tape = require("tape"),
     interpolate = require("../");
 
 tape("interpolateNumberArray(a, b) interpolates defined elements in a and b", function(test) {
-  test.deepEqual(interpolate.interpolateNumberArray(Float64Array.from([2, 12]), Float64Array.from([4, 24]))(0.5), Float64Array.from([3, 18]));
+  test.deepEqual(interpolate.interpolateNumberArray(Float64Array.of(2, 12), Float64Array.of(4, 24))(0.5), Float64Array.of(3, 18));
   test.end();
 });
 
 tape("interpolateNumberArray(a, b) ignores elements in a that are not in b", function(test) {
-  test.deepEqual(interpolate.interpolateNumberArray(Float64Array.from([2, 12, 12]), Float64Array.from([4, 24]))(0.5), Float64Array.from([3, 18]));
+  test.deepEqual(interpolate.interpolateNumberArray(Float64Array.of(2, 12, 12), Float64Array.of(4, 24))(0.5), Float64Array.of(3, 18));
   test.end();
 });
 
 tape("interpolateNumberArray(a, b) uses constant elements in b that are not in a", function(test) {
-  test.deepEqual(interpolate.interpolateNumberArray(Float64Array.from([2, 12]), Float64Array.from([4, 24, 12]))(0.5), Float64Array.from([3, 18, 12]));
+  test.deepEqual(interpolate.interpolateNumberArray(Float64Array.of(2, 12), Float64Array.of(4, 24, 12))(0.5), Float64Array.of(3, 18, 12));
   test.end();
 });
 
@@ -24,14 +24,21 @@ tape("interpolateNumberArray(a, b) treats undefined as an empty array", function
 });
 
 tape("interpolateNumberArray(a, b) uses b’s array type", function(test) {
-  test.ok(interpolate.interpolateNumberArray(Float64Array.from([2, 12]), Float64Array.from([4, 24, 12]))(0.5) instanceof Float64Array);
-  test.ok(interpolate.interpolateNumberArray(Float64Array.from([2, 12]), Float32Array.from([4, 24, 12]))(0.5) instanceof Float32Array);
-  test.ok(interpolate.interpolateNumberArray(Float64Array.from([2, 12]), Uint8Array.from([4, 24, 12]))(0.5) instanceof Uint8Array);
-  test.ok(interpolate.interpolateNumberArray(Float64Array.from([2, 12]), Uint16Array.from([4, 24, 12]))(0.5) instanceof Uint16Array);
+  test.ok(interpolate.interpolateNumberArray(Float64Array.of(2, 12), Float64Array.of(4, 24, 12))(0.5) instanceof Float64Array);
+  test.ok(interpolate.interpolateNumberArray(Float64Array.of(2, 12), Float32Array.of(4, 24, 12))(0.5) instanceof Float32Array);
+  test.ok(interpolate.interpolateNumberArray(Float64Array.of(2, 12), Uint8Array.of(4, 24, 12))(0.5) instanceof Uint8Array);
+  test.ok(interpolate.interpolateNumberArray(Float64Array.of(2, 12), Uint16Array.of(4, 24, 12))(0.5) instanceof Uint16Array);
   test.end();
 });
 
 tape("interpolateNumberArray(a, b) works with unsigned data", function(test) {
-  test.deepEqual(interpolate.interpolateNumberArray(Uint8Array.from([1, 12]), Uint8Array.from([255, 0]))(0.5), Uint8Array.from([128, 6]));
+  test.deepEqual(interpolate.interpolateNumberArray(Uint8Array.of(1, 12), Uint8Array.of(255, 0))(0.5), Uint8Array.of(128, 6));
+  test.end();
+});
+
+tape("interpolateNumberArray(a, b) gives exact ends", function(test) {
+  var i = interpolate.interpolateNumberArray(Float64Array.of(2e42), Float64Array.of(355));
+  test.deepEqual(i(0), Float64Array.of(2e42));
+  test.deepEqual(i(1), Float64Array.of(355));
   test.end();
 });

--- a/test/value-test.js
+++ b/test/value-test.js
@@ -116,14 +116,14 @@ tape("interpolate(a, b) interpolates objects with toString as objects if toStrin
 });
 
 tape("interpolate(a, b) interpolates number arrays if b is a typed array", function(test) {
-  test.deepEqual(interpolate.interpolate([0, 0], Float64Array.from([-1, 1]))(0.5), Float64Array.from([-0.5, 0.5]));
-  test.assert(interpolate.interpolate([0, 0], Float64Array.from([-1, 1]))(0.5) instanceof Float64Array);
-  test.deepEqual(interpolate.interpolate([0, 0], Float32Array.from([-1, 1]))(0.5), Float32Array.from([-0.5, 0.5]));
-  test.assert(interpolate.interpolate([0, 0], Float32Array.from([-1, 1]))(0.5) instanceof Float32Array);
-  test.deepEqual(interpolate.interpolate([0, 0], Uint32Array.from([-2, 2]))(0.5), Uint32Array.from([Math.pow(2, 31) - 1, 1]));
-  test.assert(interpolate.interpolate([0, 0], Uint32Array.from([-1, 1]))(0.5) instanceof Uint32Array);
-  test.deepEqual(interpolate.interpolate([0, 0], Uint8Array.from([-2, 2]))(0.5), Uint8Array.from([Math.pow(2, 7) - 1, 1]));
-  test.assert(interpolate.interpolate([0, 0], Uint8Array.from([-1, 1]))(0.5) instanceof Uint8Array);
+  test.deepEqual(interpolate.interpolate([0, 0], Float64Array.of(-1, 1))(0.5), Float64Array.of(-0.5, 0.5));
+  test.assert(interpolate.interpolate([0, 0], Float64Array.of(-1, 1))(0.5) instanceof Float64Array);
+  test.deepEqual(interpolate.interpolate([0, 0], Float32Array.of(-1, 1))(0.5), Float32Array.of(-0.5, 0.5));
+  test.assert(interpolate.interpolate([0, 0], Float32Array.of(-1, 1))(0.5) instanceof Float32Array);
+  test.deepEqual(interpolate.interpolate([0, 0], Uint32Array.of(-2, 2))(0.5), Uint32Array.of(Math.pow(2, 31) - 1, 1));
+  test.assert(interpolate.interpolate([0, 0], Uint32Array.of(-1, 1))(0.5) instanceof Uint32Array);
+  test.deepEqual(interpolate.interpolate([0, 0], Uint8Array.of(-2, 2))(0.5), Uint8Array.of(Math.pow(2, 7) - 1, 1));
+  test.assert(interpolate.interpolate([0, 0], Uint8Array.of(-1, 1))(0.5) instanceof Uint8Array);
   test.end();
 });
 

--- a/test/value-test.js
+++ b/test/value-test.js
@@ -115,6 +115,19 @@ tape("interpolate(a, b) interpolates objects with toString as objects if toStrin
   test.end();
 });
 
+tape("interpolate(a, b) interpolates number arrays if b is a typed array", function(test) {
+  test.deepEqual(interpolate.interpolate([0, 0], Float64Array.from([-1, 1]))(0.5), Float64Array.from([-0.5, 0.5]));
+  test.assert(interpolate.interpolate([0, 0], Float64Array.from([-1, 1]))(0.5) instanceof Float64Array);
+  test.deepEqual(interpolate.interpolate([0, 0], Float32Array.from([-1, 1]))(0.5), Float32Array.from([-0.5, 0.5]));
+  test.assert(interpolate.interpolate([0, 0], Float32Array.from([-1, 1]))(0.5) instanceof Float32Array);
+  test.deepEqual(interpolate.interpolate([0, 0], Uint32Array.from([-2, 2]))(0.5), Uint32Array.from([Math.pow(2, 31) - 1, 1]));
+  test.assert(interpolate.interpolate([0, 0], Uint32Array.from([-1, 1]))(0.5) instanceof Uint32Array);
+  test.deepEqual(interpolate.interpolate([0, 0], Uint8Array.from([-2, 2]))(0.5), Uint8Array.from([Math.pow(2, 7) - 1, 1]));
+  test.assert(interpolate.interpolate([0, 0], Uint8Array.from([-1, 1]))(0.5) instanceof Uint8Array);
+  test.end();
+});
+
+
 function noproto(properties, proto = null) {
   return Object.assign(Object.create(proto), properties);
 }


### PR DESCRIPTION
- interpolates typed arrays (Float64Array, etc) and standard arrays that contain only numbers with a simple for… loop.
- autodetects both situations (we could optionally unplug the number array detection) [EDIT: unplugged]
- not compatible with BigInt typed arrays (#75)