### PR TITLE
interpolateCubic, interpolateCubicClosed

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Returns an interpolator between the two hue angles *a* and *b*. If either hue is
 
 ### Splines
 
-Whereas standard interpolators blend from a starting value *a* at *t* = 0 to an ending value *b* at *t* = 1, spline interpolators smoothly blend multiple input values for *t* in [0,1] using piecewise polynomial functions. Only cubic uniform nonrational [B-splines](https://en.wikipedia.org/wiki/B-spline) are currently supported, also known as basis splines.
+Whereas standard interpolators blend from a starting value *a* at *t* = 0 to an ending value *b* at *t* = 1, spline interpolators smoothly blend multiple input values for *t* in [0,1] using piecewise polynomial functions. Cubic uniform nonrational [B-splines](https://en.wikipedia.org/wiki/B-spline), also known as basis splines, are supported, as well as the standard [cubic Hermite splines](https://en.wikipedia.org/wiki/Cubic_Hermite_spline).
 
 <a href="#interpolateBasis" name="interpolateBasis">#</a> d3.<b>interpolateBasis</b>(<i>values</i>) · [Source](https://github.com/d3/d3-interpolate/blob/master/src/basis.js), [Examples](https://observablehq.com/@d3/d3-interpolatebasis)
 
@@ -240,6 +240,15 @@ Returns a uniform nonrational B-spline interpolator through the specified array 
 <a href="#interpolateBasisClosed" name="interpolateBasisClosed">#</a> d3.<b>interpolateBasisClosed</b>(<i>values</i>) · [Source](https://github.com/d3/d3-interpolate/blob/master/src/basisClosed.js), [Examples](https://observablehq.com/@d3/d3-interpolatebasis)
 
 Returns a uniform nonrational B-spline interpolator through the specified array of *values*, which must be numbers. The control points are implicitly repeated such that the resulting one-dimensional spline has cyclical C² continuity when repeated around *t* in [0,1]. See also [d3.curveBasisClosed](https://github.com/d3/d3-shape/blob/master/README.md#curveBasisClosed).
+
+<a href="#interpolateCubic" name="interpolateCubic">#</a> d3.<b>interpolateCubic</b>(<i>values</i>) · [Source](https://github.com/d3/d3-interpolate/blob/master/src/cubic.js)<!-- , [Examples](https://observablehq.com/@d3/d3-interpolatecubic) -->
+
+Returns a cubic Hermite spline interpolator through the specified array of *values*, which must be numbers. The interpolator returns *values*[*i*] at *t* = *i* / (*values*.length - 1).
+
+<a href="#interpolateCubicClosed" name="interpolateCubicClosed">#</a> d3.<b>interpolateCubicClosed</b>(<i>values</i>) · [Source](https://github.com/d3/d3-interpolate/blob/master/src/cubic.js)<!-- , [Examples](https://observablehq.com/@d3/d3-interpolatecubic) -->
+
+Returns a closed cubic Hermite spline interpolator through the specified array of *values*, which must be numbers. The interpolator returns *values*[*i*] at *t* = *i* / (*values*.length), and is cyclical (*f*(1 + *t*) = *f*(*t*)).
+
 
 ### Piecewise
 

--- a/src/cubic.js
+++ b/src/cubic.js
@@ -1,0 +1,45 @@
+export default function cubic(values, type = "default") {
+  let n = values.length - 1, k;
+  values = values.slice();
+  switch (type) {
+    case "default":
+      values.push(2 * values[n] - values[n - 1]);
+      values.unshift(2 * values[0] - values[1]);
+      return t => cubic(clamp(t, 0, 1));
+    case "closed":
+      values.unshift(values[n]);
+      values.push(values[1]);
+      values.push(values[2]);
+      n += 2;
+      k = 1 - 1 / n;
+      return t => cubic(k * frac(t));
+    case "open":
+      throw new Error('open cubic spline not implemented yet');
+  }
+
+  function cubic(t) {
+    const i = Math.min(n - 1, Math.floor(t * n)),
+      v0 = values[i],
+      v1 = values[i + 1],
+      v2 = values[i + 2],
+      v3 = values[i + 3],
+      d = t * n - i,
+      s20 = v2 - v0,
+      s31 = v3 - v1,
+      s21 = (v2 - v1) * 2;
+    return (((s20 + s31 - 2 * s21) * d + (3 * s21 - 2 * s20 - s31)) * d + s20)
+      * d / 2 + v1;
+  }
+}
+
+export function closed (values) {
+  return cubic(values, "closed");
+}
+
+function frac(t) {
+  return t - Math.floor(t);
+}
+
+function clamp(t, min, max) {
+  return Math.min(max, Math.max(min, t));
+}

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export {default as interpolateBasisClosed} from "./basisClosed.js";
 export {default as interpolateDate} from "./date.js";
 export {default as interpolateDiscrete} from "./discrete.js";
 export {default as interpolateHue} from "./hue.js";
+export {default as interpolateCubic, closed as interpolateCubicClosed} from "./cubic.js";
 export {default as interpolateNumber} from "./number.js";
 export {default as interpolateNumberArray} from "./numberArray.js";
 export {default as interpolateObject} from "./object.js";

--- a/test/basis-test.js
+++ b/test/basis-test.js
@@ -1,0 +1,27 @@
+var tape = require("tape"),
+    interpolate = require("../");
+
+require("./inDelta");
+
+tape("interpolateBasis(values)(t) returns the expected values", function(test) {
+  var i = interpolate.interpolateBasis([0, 0, 3]);
+  test.equal(i(-1), 0);
+  test.equal(i(0), 0);
+  test.inDelta(i(0.19), 0.027436);
+  test.inDelta(i(0.21), 0.037044);
+  test.equal(i(1), 3);
+  test.equal(i(1.19), 3);
+  test.end();
+});
+
+tape("interpolateBasisClosed(values)(t) returns the expected values", function(test) {
+  var i = interpolate.interpolateBasisClosed([0, 0, 3]);
+  test.equal(i(-1), 0.5);
+  test.equal(i(0), 0.5);
+  test.inDelta(i(0.19), 0.132350);
+  test.inDelta(i(0.21), 0.150350);
+  test.equal(i(1), 0.5);
+  test.inDelta(i(1.19), 0.132350);
+  test.inDelta(i(0.19 - 3), 0.132350);
+  test.end();
+});

--- a/test/cubic-test.js
+++ b/test/cubic-test.js
@@ -1,0 +1,37 @@
+var tape = require("tape"),
+    interpolate = require("../");
+
+require("./inDelta");
+
+tape("interpolateCubic(values)(t) returns the expected values", function(test) {
+  var i = interpolate.interpolateCubic([0, 0, 3, 4, 1]);
+  test.equal(i(-1), 0);
+  test.equal(i(0), 0);
+  test.equal(i(0.25), 0);
+  test.equal(i(0.5), 3);
+  test.equal(i(0.75), 4);
+  test.equal(i(1), 1);
+  test.inDelta(i(0.1), -0.144);
+  test.inDelta(i(0.19), -0.207936);
+  test.inDelta(i(0.21), -0.169344);
+  test.equal(i(2), 1);
+  test.end();
+});
+
+tape("interpolateCubicClosed(values)(t) returns the expected values", function(test) {
+  var i = interpolate.interpolateCubicClosed([0, 0, 3, 4, 1]);
+  test.equal(i(0), 0);
+  test.equal(i(0.2), 0);
+  test.equal(i(0.4), 3);
+  test.equal(i(0.6), 4);
+  test.equal(i(0.8), 1);
+  test.equal(i(1), 0);
+  test.inDelta(i(0.1), -0.25);
+  test.inDelta(i(0.19), -0.068875);
+  test.inDelta(i(0.21), 0.0846875);
+  test.inDelta(i(1.1), -0.25);
+  test.inDelta(i(1.19), -0.068875);
+  test.equal(i(-1), 0);
+  test.equal(i(2), 0);
+  test.end();
+});


### PR DESCRIPTION
cubic Hermite splines ; will be useful for https://github.com/d3/d3-scale-chromatic/issues/28

The difference with interpolateBasis is that this interpolator returns the exact values at the control points; with n = values.length we have:
- values[i] = f(i/(n-1)) for interpolateCubic
- values[i] = f(i/n) for interpolateCubicClosed, with f(1) == f(0)
 
