### PR TITLE
Avoid negative duration in interpolateZoom

### DIFF
--- a/src/zoom.js
+++ b/src/zoom.js
@@ -57,7 +57,7 @@ export default (function zoomRho(rho, rho2, rho4) {
       }
     }
 
-    i.duration = S * 1000 * rho / Math.SQRT2;
+    i.duration = Math.abs(S) * 1000 * rho / Math.SQRT2;
 
     return i;
   }


### PR DESCRIPTION
See #101.

It's a simple change. I'm not aware of any case where allowing a negative duration would be useful&mdash;let me know if I'm wrong.